### PR TITLE
Use jbuilder clean in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ doc:
 
 
 clean:
-	rm -R _build
+	jbuilder clean

--- a/odoc.opam
+++ b/odoc.opam
@@ -14,7 +14,7 @@ available: [ ocaml-version >= "4.03.0" ]
 
 depends: [
   "ocamlfind" {build}
-  "jbuilder" {build}
+  "jbuilder" {build & >= "1.0+beta10"}
   "doc-ock"
   "doc-ock-html"
   "doc-ock-xml"


### PR DESCRIPTION
- The previous `make clean` did not work correctly in a Jbuilder workspace.
- The previous `make clean` failed if the repo was already clean.

The `jbuilder clean` command requires Jbuilder >= 1.0+beta10.