### PR TITLE
Force <i> font style to italic

### DIFF
--- a/etc/odoc.css
+++ b/etc/odoc.css
@@ -33,7 +33,7 @@ body
 /* Basic markup elements */
 
 b, strong { font-weight: bold; }
-em { font-style: italic; }
+i, em { font-style: italic; }
 
 sup { vertical-align: super; }
 sub { vertical-align: sub; }


### PR DESCRIPTION
`<i>` tags generated by `{i foo}` weren't rendered in italic. This patch simply applies the same treatment as `<b>` tags.

I checked by manually editing `odoc.css` in another project that the issue is fixed.