### PR TITLE
css: fix codeblock overflow

### DIFF
--- a/etc/odoc.css
+++ b/etc/odoc.css
@@ -111,7 +111,7 @@ pre
   padding-top: 0.3125rem; padding-bottom: 0.3125rem;
   margin-top: 1.25rem; /*  margin-bottom: 0.625rem; */
   line-height: 1.1875rem;
-  background: #F1F1F1; }
+  background: #F1F1F1; overflow: auto; }
 
 h1 tt, h1 code, h2 tt, h2 code, .h7 tt, .h7 code { font-size: 1.125rem }
 h3 tt, h3 code { font-size: 1rem }


### PR DESCRIPTION
small css fix that allows you to scroll in codeblocks, preventing text overflow

before:

![image](https://user-images.githubusercontent.com/4206232/37563392-dc46e4de-2a3c-11e8-84fb-41eda50cff1b.png)

after:

![image](https://user-images.githubusercontent.com/4206232/37563395-e3230134-2a3c-11e8-9fb4-da398cf5db9e.png)
